### PR TITLE
Modify GitHub Actions workflow to cache Gradle dependencies

### DIFF
--- a/.github/workflows/Build&Simulate.yml
+++ b/.github/workflows/Build&Simulate.yml
@@ -4,13 +4,23 @@ on: [push, pull_request]  # Trigger the workflow on push events
 
 jobs:
   Simulate:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     container: wpilib/roborio-cross-ubuntu:2025-24.04
     steps:
 
       - uses: actions/checkout@v4
       - name: Grant execute permission # just in case
         run: chmod +x gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Build Robot Code
         run: ./gradlew build


### PR DESCRIPTION
Modify the GitHub Actions workflow to cache Gradle dependencies.

* Change the runner to `ubuntu-latest`.
* Add a new step to cache Gradle dependencies using `actions/cache@v3`.
* Specify the `path` to include `~/.gradle/caches` and `~/.gradle/wrapper`.
* Generate the `key` based on the operating system and the hash of the Gradle files.
* Add `restore-keys` to allow the cache to be restored if an exact match is not found.

