### PR TITLE
Improve caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/Build&Simulate.yml
+++ b/.github/workflows/Build&Simulate.yml
@@ -18,9 +18,12 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-caches-
+            ${{ runner.os }}-gradle-wrapper-
 
       - name: Build Robot Code
         run: ./gradlew build
@@ -30,7 +33,7 @@ jobs:
     
       - name: Simulate Robot Code
         run: |
-          timeout 60s ./gradlew simulateJava || exit_code=$?
+          timeout 20s ./gradlew simulateJava || exit_code=$?
           if [ $exit_code -eq 124 ]; then
             echo "Command exited with code 124, ignoring"
             exit 0


### PR DESCRIPTION
Update GitHub Actions workflow to cache additional directories and implement cache fallback strategies.

* Add `~/.gradle` to the `path` key in the `actions/cache@v3` step.
* Add additional `restore-keys` for cache fallback strategies in the `actions/cache@v3` step.
* Change the timeout for the `simulateJava` command from 60s to 20s.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WestwoodRobotics/2025KiwiBeta/pull/9?shareId=2a495279-9241-4293-bd0f-db61cb1fe216).